### PR TITLE
Feature: support GitHub enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ If no files are specified, all workflow files (.yml or .yaml) in the current dir
 ### Flags
 
 - `--api-server` — Full GitHub API base URL (e.g., `https://github.enterprise.company.com/api/v3/`).
-- `--github-token` — GitHub.com token (also via `GITHUB_TOKEN`).
+- `--ghes-github-token` — Token for GHES API requests (also via `GHES_GITHUB_TOKEN`).
+- `--github-token` — GitHub.com token for default and fallback requests (also via `GITHUB_TOKEN`).
 - Other existing flags remain unchanged (ignore-owners, ignore-repos, strict-pinning-202508, etc.).
 
 ### GHES fallback behavior

--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ If no files are specified, all workflow files (.yml or .yaml) in the current dir
 
 * You can specify and use only the official Github Environment variables, already present during CICD, or specify a configuration file for the command execution.
 
+## Tokens and GHES support
+
+- **GitHub.com (default API)**  
+  - `GITHUB_TOKEN` (required)
+
+- **GitHub Enterprise Server (GHES) or any non-github.com API base**  
+  - `pin.api-server` (or `GITHUB_API_URL`) must be the full API base URL (e.g., `https://github.enterprise.company.com/api/v3/`).  
+  - `GHES_GITHUB_TOKEN` (required) — used for GHES API requests.  
+  - `GITHUB_TOKEN` (required) — used for GitHub.com fallback when GHES returns 404 on tags.
+
+### Flags
+
+- `--api-server` — Full GitHub API base URL (e.g., `https://github.enterprise.company.com/api/v3/`).
+- `--github-token` — GitHub.com token (also via `GITHUB_TOKEN`).
+- Other existing flags remain unchanged (ignore-owners, ignore-repos, strict-pinning-202508, etc.).
+
+### GHES fallback behavior
+
+When `api-server` is not `https://api.github.com/`, gha-fix:
+1. Uses `GHES_GITHUB_TOKEN` against the GHES API.
+2. If a tag listing returns 404, it retries against `https://api.github.com/` using `GITHUB_TOKEN`.
+
 ## Configuration file (gha-fix.yaml)
 
 `gha-fix` can be configured via a YAML file named `gha-fix.yaml` in the current directory, or by passing `--config /path/to/gha-fix.yaml`.
@@ -51,7 +73,7 @@ Configuration sources follow typical precedence rules:
 
 ### `pin:` section
 
-- `pin.github-token` (string): GitHub token used for API calls to resolve tags and branch heads.
+- `pin.github-token` (string): GitHub token used for GitHub.com API calls (default or fallback).
   - Env alternative: `GITHUB_TOKEN` (bound to `pin.github-token`).
 - `pin.api-server` (string): **full GitHub API base URL** (e.g., `https://github.enterprise.company.com/api/v3/`).
   - If not set, `gha-fix` uses `GITHUB_API_URL`.
@@ -62,7 +84,6 @@ Configuration sources follow typical precedence rules:
 
 * `timeout:` section:
 - `timeout.timeout-value` (int): value (minutes) inserted by `gha-fix timeout` for jobs missing `timeout-minutes`.
-
 
 ## Example `gha-fix.yaml`
 
@@ -81,8 +102,8 @@ pin:
   # If omitted, gha-fix falls back to GITHUB_API_URL, then https://api.github.com/.
   api-server: "https://github.enterprise.company.com/api/v3/"
 
-  # GitHub token used to call the GitHub API for resolving tags/branches to commit SHAs.
-  # You can also set this via the GITHUB_TOKEN env var (recommended for CI).
+  # GitHub token used to call the GitHub.com API for resolving tags/branches to commit SHAs
+  # (default or fallback when GHES returns 404).
   github-token: "${GITHUB_TOKEN}"
 
   # Owners to ignore during pinning (unless strict-pinning-202508 is enabled for composite actions).
@@ -102,6 +123,11 @@ timeout:
   # Default timeout-minutes value inserted by `gha-fix timeout`
   timeout-value: 5
 ```
+
+Env fallbacks:
+- `pin.github-token` ⇔ `GITHUB_TOKEN`
+- `pin.api-server` ⇔ `GITHUB_API_URL`
+- GHES primary token (env only): `GHES_GITHUB_TOKEN`
 
 ### Using a non-default config path
 
@@ -124,6 +150,7 @@ Supported configuration (highest priority first):
 Example (GHES):
 
 ```bash
+export GHES_GITHUB_TOKEN=...
 export GITHUB_TOKEN=...
 export GITHUB_API_URL="https://github.enterprise.company.com/api/v3/"
 gha-fix pin
@@ -219,4 +246,3 @@ In addition to this inspiration, `gha-fix` was developed to support new features
 ### Release
 
 Create a Git tag and push it. The CI/CD pipeline will take care of the release process.
-

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Configuration sources follow typical precedence rules:
   - If neither is set, defaults to `https://api.github.com/`.
 - `pin.ignore-owners` (string list): owners to skip pinning (e.g., `actions`, `github`).
 - `pin.ignore-repos` (string list): repositories to skip pinning, format `owner/repo`.
+- `pin.restrict-to-files` (string list): restrict processing to only these workflow files (useful for PR changed-files workflows).
 - `pin.strict-pinning-202508` (bool): enables strict SHA pinning behavior for composite actions (see “Strict SHA Pinning” section).
 
 * `timeout:` section:
@@ -116,6 +117,12 @@ pin:
   ignore-repos:
     - actions/checkout
     - docker/login-action
+
+  # Restrict processing to specific workflow files (optional).
+  # If set, gha-fix will only process these files.
+  restrict-to-files:
+    - .github/workflows/build.yml
+    - .github/workflows/deploy.yml
 
   # Enable strict SHA pinning enforcement behavior for composite actions (see below).
   strict-pinning-202508: false
@@ -192,6 +199,9 @@ gha-fix pin
 
 # Ignore specific owners
 gha-fix pin --ignore-owners=actions,github
+
+# Restrict processing to specific files (comma-separated list)
+gha-fix pin --restrict-to-files=.github/workflows/build.yml,.github/workflows/deploy.yml
 
 # Enable strict SHA pinning for composite actions (GitHub's SHA pinning enforcement policy)
 gha-fix pin --strict-pinning-202508

--- a/README.md
+++ b/README.md
@@ -32,6 +32,34 @@ If no files are specified, all workflow files (.yml or .yaml) in the current dir
 #### GitHub Token Configuration
 `GITHUB_TOKEN` is required to fetch tags and commit SHAs from GitHub. Can be provided via environment variable or other ways.
 
+#### GitHub API Server (GHES support)
+
+By default, `gha-fix` uses the GitHub.com API (`https://api.github.com/`). To use GitHub Enterprise Server (GHES) or any other deployment, set the **full API base URL**.
+
+Supported configuration (highest priority first):
+
+1. CLI flag: `gha-fix pin --api-server <FULL_API_BASE_URL>`
+2. Config file key: `pin.api-server`
+3. Environment variable: `GITHUB_API_URL`
+4. Default: `https://api.github.com/`
+
+Example (GHES):
+
+```bash
+export GITHUB_TOKEN=...
+export GITHUB_API_URL="https://github.enterprise.company.com/api/v3/"
+gha-fix pin
+```
+
+Or with config file (`gha-fix.yaml`):
+
+```yaml
+pin:
+  api-server: "https://github.enterprise.company.com/api/v3/"
+```
+
+Note: `api-server` must be the **full API base URL** for your deployment. `gha-fix` will not assume `/api/v3`.
+
 #### Strict SHA Pinning (--strict-pinning-202508)
 
 The `--strict-pinning-202508` option implements support for GitHub's SHA pinning enforcement policy announced in August 2025. When enabled, this option modifies the behavior of ignore-owners:
@@ -57,6 +85,9 @@ gha-fix pin --ignore-owners=actions,github
 
 # Enable strict SHA pinning for composite actions (GitHub's SHA pinning enforcement policy)
 gha-fix pin --strict-pinning-202508
+
+# Use GHES API server explicitly
+gha-fix pin --api-server "https://github.enterprise.company.com/api/v3/"
 
 # Ignore specific directories when searching for workflow files (global option)
 # This will skip any directory with these names, including in subdirectories (e.g., abc/def/node_modules/)
@@ -104,3 +135,4 @@ In addition to this inspiration, `gha-fix` was developed to support new features
 ## Development
 ### Release
 Create a Git tag and push it. The CI/CD pipeline will take care of the release process.
+

--- a/cmd/gha-fix/pin.go
+++ b/cmd/gha-fix/pin.go
@@ -195,8 +195,13 @@ func init() {
 	cobra.CheckErr(viper.BindEnv("pin.ghes-github-token", "GHES_GITHUB_TOKEN"))
 
 	pinCmd.Flags().StringSlice("ignore-owners", []string{}, "Comma-separated list of owners to ignore")
+	cobra.CheckErr(viper.BindPFlag("pin.ignore-owners", pinCmd.Flags().Lookup("ignore-owners")))
+
 	pinCmd.Flags().StringSlice("ignore-repos", []string{}, "Comma-separated list of repos to ignore in format owner/repo")
+	cobra.CheckErr(viper.BindPFlag("pin.ignore-repos", pinCmd.Flags().Lookup("ignore-repos")))
+
 	pinCmd.Flags().Bool("strict-pinning-202508", false, "Enable strict SHA pinning for composite actions (GitHub's SHA pinning enforcement policy)")
+	cobra.CheckErr(viper.BindPFlag("pin.strict-pinning-202508", pinCmd.Flags().Lookup("strict-pinning-202508")))
 
 	// Full GitHub API base URL (GHES support)
 	pinCmd.Flags().String("api-server", "", "Full GitHub API base URL (e.g., https://github.enterprise.company.com/api/v3/)")

--- a/cmd/gha-fix/pin.go
+++ b/cmd/gha-fix/pin.go
@@ -46,6 +46,27 @@ Global options:
 
 Note: GITHUB_TOKEN environment variable is required to fetch tags and commit SHAs from GitHub.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// At the start of pinCmd.Run (inside Run: func(cmd *cobra.Command, args []string) { ... })
+		if slog.Default().Enabled(ctx, slog.LevelDebug) {
+			ownersFlag, _ := cmd.Flags().GetStringSlice("ignore-owners")
+			reposFlag, _ := cmd.Flags().GetStringSlice("ignore-repos")
+			strictFlag, _ := cmd.Flags().GetBool("strict-pinning-202508")
+		
+			slog.Debug("cobra parsed flags (pin command)",
+				"ignore-owners(flag)", ownersFlag,
+				"ignore-repos(flag)", reposFlag,
+				"strict-pinning-202508(flag)", strictFlag,
+			)
+		
+			slog.Debug("viper effective values (pin command)",
+				"pin.ignore-owners(viper)", viper.GetStringSlice("pin.ignore-owners"),
+				"pin.ignore-repos(viper)", viper.GetStringSlice("pin.ignore-repos"),
+				"pin.strict-pinning-202508(viper)", viper.GetBool("pin.strict-pinning-202508"),
+				"ignore-dirs(viper)", viper.GetStringSlice("ignore-dirs"),
+				"pin.api-server(viper)", viper.GetString("pin.api-server"),
+			)
+		}
+		
 		ctx := context.Background()
 
 		// Resolve API base

--- a/cmd/gha-fix/pin.go
+++ b/cmd/gha-fix/pin.go
@@ -24,9 +24,9 @@ Usage:
 If no files are specified, all workflow files (.yml or .yaml) in the current directory
 and subdirectories will be processed.
 
-You can customize the behavior with the following options:
+	You can customize the behavior with the following options:
   --github-token: GitHub token for accessing GitHub API (can also be set via GITHUB_TOKEN env var or pin.github-token in config)
-  --ghes-github-token: Github token for Github enterprise sever (can also be set via GHES_GITHUB_TOKEN env var or pin.ghes-github-token in config)
+  --ghes-github-token: GitHub token for GitHub Enterprise Server (can also be set via GHES_GITHUB_TOKEN env var or pin.ghes-github-token in config)
   --ignore-owners: Skip actions from specific owners (e.g., "actions,github")
   --ignore-repos: Skip specific repositories (e.g., "actions/checkout,docker/login-action")
   --strict-pinning-202508: Enable strict SHA pinning for composite actions (GitHub's SHA pinning enforcement policy)

--- a/cmd/gha-fix/pin.go
+++ b/cmd/gha-fix/pin.go
@@ -18,9 +18,7 @@ var pinCmd = &cobra.Command{
 	Long: `Pin GitHub Actions in workflow files to specific commit SHAs to enhance security and reliability.
 
 This command scans workflow files for GitHub Actions and replaces version references with specific commit SHAs.
-It supports various options to customize its behavior. For example, 'owner/repo@v1' with specific commit SHAs 
-like 'owner/repo@8843d7f53bd34e3b78f2acee556ba5d53feae7c4'.
-It supports various options to customize its behavior.
+It supports various options to customize its behavior. For example, it can replace 'owner/repo@v1' with a specific commit SHA like 'owner/repo@8843d7f53bd34e3b78f2acee556ba5d53feae7c4'.
 Usage:
   pin [file1 file2 ...]
 If no files are specified, all workflow files (.yml or .yaml) in the current directory

--- a/cmd/gha-fix/pin.go
+++ b/cmd/gha-fix/pin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 

--- a/cmd/gha-fix/pin.go
+++ b/cmd/gha-fix/pin.go
@@ -113,6 +113,33 @@ Note: GITHUB_TOKEN environment variable is required to fetch tags and commit SHA
 			StrictPinning202508: strictPinning202508,
 		})
 
+		// Add full logging of the config before starting the execution
+		if slog.Default().Enabled(ctx, slog.LevelDebug) {
+			settings := viper.AllSettings()
+	
+			// Best-effort redaction. (Covers the config keys used by this tool.)
+			if pin, ok := settings["pin"].(map[string]any); ok {
+				if _, exists := pin["github-token"]; exists {
+					pin["github-token"] = "***REDACTED***"
+				}
+				if _, exists := pin["ghes-github-token"]; exists {
+					pin["ghes-github-token"] = "***REDACTED***"
+				}
+			}
+			
+			// Also avoid leaking env-derived values that might appear elsewhere.
+			if _, exists := settings["github-token"]; exists {
+				settings["github-token"] = "***REDACTED***"
+			}
+			
+			b, err := json.MarshalIndent(settings, "", "  ")
+			if err != nil {
+				slog.Debug("failed to marshal viper settings", "error", err)
+			} else {
+				slog.Debug("viper all settings", "json", string(b))
+			}
+		}
+
 		result, err := pinCmd.Run(ctx, args)
 		if err != nil {
 			slog.Error("failed to pin actions", "error", err)

--- a/cmd/gha-fix/pin.go
+++ b/cmd/gha-fix/pin.go
@@ -12,24 +12,26 @@ import (
 )
 
 var pinCmd = &cobra.Command{
-	Use:   "pin",
-	Short: "Pin GitHub Actions to specific commit SHAs",
-	Long: `Pin GitHub Actions used in workflow files (.yml or .yaml) to specific commit SHAs.
+	Use:   "pin [file1 file2 ...]",
+	Short: "Pin GitHub Actions in workflow files to specific commit SHAs",
+	Long: `Pin GitHub Actions in workflow files to specific commit SHAs to enhance security and reliability.
 
-This command scans GitHub Actions in workflow files and replaces references like 'owner/repo@v1'
-with specific commit SHAs like 'owner/repo@8843d7f53bd34e3b78f2acee556ba5d53feae7c4'.
-
+This command scans workflow files for GitHub Actions and replaces version references with specific commit SHAs.
+It supports various options to customize its behavior. For example, 'owner/repo@v1' with specific commit SHAs 
+like 'owner/repo@8843d7f53bd34e3b78f2acee556ba5d53feae7c4'.
+It supports various options to customize its behavior.
 Usage:
   pin [file1 file2 ...]
-
 If no files are specified, all workflow files (.yml or .yaml) in the current directory
 and subdirectories will be processed.
 
 You can customize the behavior with the following options:
+  --github-token: GitHub token for accessing GitHub API (can also be set via GITHUB_TOKEN env var or pin.github-token in config)
+  --ghes-github-token: Github token for Github enterprise sever (can also be set via GHES_GITHUB_TOKEN env var or pin.ghas-github-token in config)
   --ignore-owners: Skip actions from specific owners (e.g., "actions,github")
   --ignore-repos: Skip specific repositories (e.g., "actions/checkout,docker/login-action")
   --strict-pinning-202508: Enable strict SHA pinning for composite actions (GitHub's SHA pinning enforcement policy)
-  --api-server: Full GitHub API base URL (e.g., https://github.enterprise.company.com/api/v3/)
+  --api-server: Full GitHub API base URL assuming https://api.github.com when not specified (e.g., https://github.enterprise.company.com/api/v3)
 
 The --strict-pinning-202508 option implements support for GitHub's SHA pinning enforcement policy
 announced in August 2025. When enabled:
@@ -43,29 +45,60 @@ Global options:
   --ignore-dirs: Skip specific directories when searching for workflow files (e.g., "node_modules,dist")
 
 Note: GITHUB_TOKEN environment variable is required to fetch tags and commit SHAs from GitHub.`,
-
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 
-		githubToken := viper.GetString("pin.github-token")
-		if githubToken == "" {
-			slog.Error("GitHub token is required. Use --github-token flag, GITHUB_TOKEN env var, or pin.github-token in config file.")
-			os.Exit(1)
-		}
-
-		// API server resolution priority:
-		// 1) pin.api-server (flag/config)
-		// 2) GITHUB_API_URL env var
-		// 3) default https://api.github.com/
+		// Resolve API base
 		apiServer := viper.GetString("pin.api-server")
 		if apiServer == "" {
 			apiServer = os.Getenv("GITHUB_API_URL")
 		}
-
-		githubClient, err := githubclient.NewClient(githubToken, apiServer)
+		apiServer, err := githubclient.NormalizeAPIBaseURL(apiServer)
 		if err != nil {
-			slog.Error("failed to create GitHub client", "error", err)
+			slog.Error("invalid api-server", "error", err)
 			os.Exit(1)
+		}
+		if apiServer == "" {
+			apiServer = githubclient.DefaultAPIBaseURL
+		}
+		isDefaultAPI := apiServer == githubclient.DefaultAPIBaseURL
+
+		// Tokens
+		var primaryToken string
+		var fallbackToken string
+
+		if isDefaultAPI {
+			primaryToken = viper.GetString("pin.github-token") // bound to GITHUB_TOKEN or flag/config
+			if primaryToken == "" {
+				slog.Error("GITHUB_TOKEN is required for GitHub.com API calls. Use --github-token flag, GITHUB_TOKEN env var, or pin.github-token in config file.")
+				os.Exit(1)
+			}
+		} else {
+			primaryToken = os.Getenv("GHES_GITHUB_TOKEN")
+			if primaryToken == "" {
+				slog.Error("GHES_GITHUB_TOKEN is required when api-server is not https://api.github.com/. Set GHES_GITHUB_TOKEN for your GHES API.")
+				os.Exit(1)
+			}
+			fallbackToken = viper.GetString("pin.github-token") // GITHUB_TOKEN
+			if fallbackToken == "" {
+				slog.Error("GITHUB_TOKEN is required for GitHub.com fallback when api-server is not https://api.github.com/. Set GITHUB_TOKEN to enable fallback tag resolution.")
+				os.Exit(1)
+			}
+		}
+
+		primaryClient, err := githubclient.NewClient(primaryToken, apiServer)
+		if err != nil {
+			slog.Error("failed to create primary GitHub client", "error", err)
+			os.Exit(1)
+		}
+
+		var fallbackClient *githubclient.Client
+		if !isDefaultAPI {
+			fallbackClient, err = githubclient.NewClient(fallbackToken, githubclient.DefaultAPIBaseURL)
+			if err != nil {
+				slog.Error("failed to create fallback GitHub.com client", "error", err)
+				os.Exit(1)
+			}
 		}
 
 		// Get values from viper which can come from flags, config file, or environment variables
@@ -74,7 +107,7 @@ Note: GITHUB_TOKEN environment variable is required to fetch tags and commit SHA
 		ignoreDirs := viper.GetStringSlice("ignore-dirs") // Use common ignore-dirs configuration
 		strictPinning202508 := viper.GetBool("pin.strict-pinning-202508")
 
-		pinCmd := ghafix.NewPinCommand(githubClient, ghafix.PinOptions{
+		pinCmd := ghafix.NewPinCommand(primaryClient, fallbackClient, ghafix.PinOptions{
 			IgnoreOwners:        ignoreOwners,
 			IgnoreRepos:         ignoreRepos,
 			IgnoreDirs:          ignoreDirs,
@@ -116,9 +149,4 @@ func init() {
 	// Full GitHub API base URL (GHES support)
 	pinCmd.Flags().String("api-server", "", "Full GitHub API base URL (e.g., https://github.enterprise.company.com/api/v3/)")
 	cobra.CheckErr(viper.BindPFlag("pin.api-server", pinCmd.Flags().Lookup("api-server")))
-
-	cobra.CheckErr(viper.BindPFlag("pin.ignore-owners", pinCmd.Flags().Lookup("ignore-owners")))
-	cobra.CheckErr(viper.BindPFlag("pin.ignore-repos", pinCmd.Flags().Lookup("ignore-repos")))
-	cobra.CheckErr(viper.BindPFlag("pin.strict-pinning-202508", pinCmd.Flags().Lookup("strict-pinning-202508")))
 }
-

--- a/cmd/gha-fix/pin.go
+++ b/cmd/gha-fix/pin.go
@@ -30,7 +30,7 @@ and subdirectories will be processed.
   --ignore-owners: Skip actions from specific owners (e.g., "actions,github")
   --ignore-repos: Skip specific repositories (e.g., "actions/checkout,docker/login-action")
   --strict-pinning-202508: Enable strict SHA pinning for composite actions (GitHub's SHA pinning enforcement policy)
-  --api-server: Full GitHub API base URL assuming https://api.github.com when not specified (e.g., https://github.enterprise.company.com/api/v3)
+  --api-server: Full GitHub API base URL (defaults to https://api.github.com/ when not specified, e.g., https://github.enterprise.company.com/api/v3)
 
 The --strict-pinning-202508 option implements support for GitHub's SHA pinning enforcement policy
 announced in August 2025. When enabled:

--- a/cmd/gha-fix/pin.go
+++ b/cmd/gha-fix/pin.go
@@ -46,7 +46,8 @@ Global options:
 
 Note: GITHUB_TOKEN environment variable is required to fetch tags and commit SHAs from GitHub.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// At the start of pinCmd.Run (inside Run: func(cmd *cobra.Command, args []string) { ... })
+		ctx := context.Background()
+
 		if slog.Default().Enabled(ctx, slog.LevelDebug) {
 			ownersFlag, _ := cmd.Flags().GetStringSlice("ignore-owners")
 			reposFlag, _ := cmd.Flags().GetStringSlice("ignore-repos")
@@ -66,8 +67,6 @@ Note: GITHUB_TOKEN environment variable is required to fetch tags and commit SHA
 				"pin.api-server(viper)", viper.GetString("pin.api-server"),
 			)
 		}
-		
-		ctx := context.Background()
 
 		// Resolve API base
 		apiServer := viper.GetString("pin.api-server")

--- a/ghafix.go
+++ b/ghafix.go
@@ -28,10 +28,11 @@ type PinCommand struct {
 	options PinOptions
 }
 
-// NewPinCommand creates a new PinCommand with the provided GitHub client and options.
-func NewPinCommand(client *gogithub.Client, opts PinOptions) PinCommand {
+// NewPinCommand creates a new PinCommand with the provided GitHub clients and options.
+// primaryClient is required. fallbackClient (GitHub.com) is optional and used for tag resolution fallback.
+func NewPinCommand(primaryClient *gogithub.Client, fallbackClient *gogithub.Client, opts PinOptions) PinCommand {
 	return PinCommand{
-		pin:     pin.NewPin(client, opts.IgnoreOwners, opts.IgnoreRepos, opts.StrictPinning202508),
+		pin:     pin.NewPin(primaryClient, fallbackClient, opts.IgnoreOwners, opts.IgnoreRepos, opts.StrictPinning202508),
 		options: opts,
 	}
 }

--- a/internal/githubclient/client.go
+++ b/internal/githubclient/client.go
@@ -1,0 +1,69 @@
+package githubclient
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	gogithub "github.com/google/go-github/v72/github"
+)
+
+const DefaultAPIBaseURL = "https://api.github.com/"
+
+// NormalizeAPIBaseURL normalizes a GitHub API base URL ensuring it has a trailing slash
+// and is a valid absolute URL.
+//
+// The input is expected to be a full API base URL, e.g.
+//   - https://github.enterprise.company.com/api/v3/
+//   - https://api.github.com/
+func NormalizeAPIBaseURL(raw string) (string, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return "", nil
+	}
+	if !strings.HasSuffix(s, "/") {
+		s += "/"
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", errors.Wrap(err, "parse api server url")
+	}
+	if !u.IsAbs() {
+		return "", errors.New("api server url must be absolute")
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return "", errors.New("api server url scheme must be http or https")
+	}
+
+	return u.String(), nil
+}
+
+// NewClient creates a go-github client using the provided auth token and API base URL.
+//
+// apiBaseURL is a full API base URL. If empty, DefaultAPIBaseURL is used.
+func NewClient(token string, apiBaseURL string) (*gogithub.Client, error) {
+	base := apiBaseURL
+	if strings.TrimSpace(base) == "" {
+		base = DefaultAPIBaseURL
+	}
+
+	base, err := NormalizeAPIBaseURL(base)
+	if err != nil {
+		return nil, err
+	}
+
+	// go-github uses BaseURL for API requests and UploadURL for uploads.
+	// We only need API requests for this tool, but WithEnterpriseURLs sets both consistently.
+	c := gogithub.NewClient(nil).WithAuthToken(token)
+
+	if base != DefaultAPIBaseURL {
+		c, err = c.WithEnterpriseURLs(base, base)
+		if err != nil {
+			return nil, errors.Wrap(err, "set enterprise urls")
+		}
+	}
+
+	return c, nil
+}
+

--- a/internal/githubclient/client_test.go
+++ b/internal/githubclient/client_test.go
@@ -1,0 +1,47 @@
+package githubclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAPIBaseURL(t *testing.T) {
+	t.Run("empty is allowed", func(t *testing.T) {
+		got, err := NormalizeAPIBaseURL("")
+		require.NoError(t, err)
+		require.Equal(t, "", got)
+	})
+
+	t.Run("adds trailing slash", func(t *testing.T) {
+		got, err := NormalizeAPIBaseURL("https://ghe.example.com/api/v3")
+		require.NoError(t, err)
+		require.Equal(t, "https://ghe.example.com/api/v3/", got)
+	})
+
+	t.Run("keeps trailing slash", func(t *testing.T) {
+		got, err := NormalizeAPIBaseURL("https://api.github.com/")
+		require.NoError(t, err)
+		require.Equal(t, "https://api.github.com/", got)
+	})
+
+	t.Run("rejects relative url", func(t *testing.T) {
+		_, err := NormalizeAPIBaseURL("/api/v3/")
+		require.Error(t, err)
+	})
+}
+
+func TestNewClient(t *testing.T) {
+	t.Run("default base url when empty", func(t *testing.T) {
+		c, err := NewClient("t", "")
+		require.NoError(t, err)
+		require.Equal(t, DefaultAPIBaseURL, c.BaseURL.String())
+	})
+
+	t.Run("enterprise base url is applied when provided", func(t *testing.T) {
+		c, err := NewClient("t", "https://ghe.example.com/api/v3")
+		require.NoError(t, err)
+		require.Equal(t, "https://ghe.example.com/api/v3/", c.BaseURL.String())
+	})
+}
+

--- a/internal/pin/version_resolver.go
+++ b/internal/pin/version_resolver.go
@@ -115,7 +115,13 @@ func (r *VersionResolver) ResolveVersion(ctx context.Context, def ActionDef) (Re
 	// The ref is not a version tag, so treat it as a branch name.
 	if version == nil {
 		slog.Debug("fetching commit SHA for branch", "owner", def.Owner, "repo", def.Repo, "ref", def.RefOrSHA)
+		// inside ResolveVersion, branch path (version == nil)
 		sha, _, err := r.repoService.GetCommitSHA1(ctx, def.Owner, def.Repo, def.RefOrSHA, "")
+		if err != nil && r.fallbackRepoService != nil && isNotFound(err) {
+			slog.Debug("GHES API returned 404 for commit; falling back to GitHub.com",
+				"owner", def.Owner, "repo", def.Repo, "ref", def.RefOrSHA)
+			sha, _, err = r.fallbackRepoService.GetCommitSHA1(ctx, def.Owner, def.Repo, def.RefOrSHA, "")
+		}
 		if err != nil {
 			return ResolvedVersion{}, errors.Wrapf(err, "failed to get commit SHA for %s/%s@%s", def.Owner, def.Repo, def.RefOrSHA)
 		}

--- a/internal/pin/version_resolver.go
+++ b/internal/pin/version_resolver.go
@@ -201,7 +201,8 @@ func (r *VersionResolver) listTagsAll(ctx context.Context, owner, repo string) (
 	}
 
 	if r.fallbackRepoService != nil && isNotFound(err) {
-		slog.Debug("primary API returned 404; falling back to GitHub.com", "owner", owner, "repo", repo)
+		// Log both attempts for clarity when GHES misses tags and we retry against GitHub.com.
+		slog.Debug("GHES returned 404; falling back to GitHub.com", "owner", owner, "repo", repo)
 		return fetchAll(r.fallbackRepoService)
 	}
 

--- a/internal/pin/version_resolver_test.go
+++ b/internal/pin/version_resolver_test.go
@@ -23,7 +23,7 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			GetCommitSHA1(gomock.Any(), "actions", "checkout", "main", "").
 			Return("11bd71901bbe5b1630ceea73d27597364c9af683", &gogithub.Response{}, nil).Times(1)
 
-		resolver := NewVersionResolver(mockRepo)
+		resolver := NewVersionResolver(mockRepo, nil)
 
 		// First call should hit the API
 		def := ActionDef{
@@ -60,7 +60,7 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 			ListTags(gomock.Any(), "actions", "checkout", gomock.Any()).
 			Return(tags, &gogithub.Response{NextPage: 0}, nil).Times(1)
 
-		resolver := NewVersionResolver(mockRepo)
+		resolver := NewVersionResolver(mockRepo, nil)
 
 		def := ActionDef{
 			Owner:    "actions",
@@ -166,7 +166,7 @@ func TestVersionResolver_ResolveVersion(t *testing.T) {
 				tt.mockSetup(mockRepo)
 			}
 
-			resolver := NewVersionResolver(mockRepo)
+			resolver := NewVersionResolver(mockRepo, nil)
 
 			result, err := resolver.ResolveVersion(context.Background(), tt.actionDef)
 			require.NoError(t, err)
@@ -197,7 +197,7 @@ func TestVersionResolver_listSemverTagsAll(t *testing.T) {
 			createTag("not-semver", "sha4"), // This should be filtered out
 		}, &gogithub.Response{NextPage: 0}, nil)
 
-	resolver := NewVersionResolver(mockRepo)
+	resolver := NewVersionResolver(mockRepo, nil)
 
 	tags, err := resolver.listSemverTagsAll(context.Background(), "owner", "repo")
 

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -79,6 +79,17 @@ func (p *Pin) replaceLine(ctx context.Context, line string) (string, bool, error
 	}
 	def := parsed.def
 
+	// log debug to show exactly what the current replacement is... 
+	slog.Debug("pin decision",
+		"owner", def.Owner,
+		"repo", def.Repo,
+		"ref", def.RefOrSHA,
+		"is_reusable_workflow", def.IsReusableWorkflow(),
+		"strict_pinning_202508", p.strictPinning202508,
+		"ignore_owners", p.ignoreOwners,
+		"ignore_repos", p.ignoreRepos,
+	)
+
 	// Apply ignore owners check (skip for composite actions when strict pinning is enabled)
 	if !p.strictPinning202508 || def.IsReusableWorkflow() {
 		if slices.Contains(p.ignoreOwners, def.Owner) {

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -25,10 +25,11 @@ type Pin struct {
 
 // NewPin creates a pin command with primary GitHub client and optional fallback GitHub.com client.
 func NewPin(primaryClient *gogithub.Client, fallbackClient *gogithub.Client, ignoreOwners, ignoreRepos []string, strictPinning202508 bool) Pin {
-	resolver := pin.NewVersionResolver(primaryClient.Repositories, nil)
+	var fallbackRepos *gogithub.RepositoriesService
 	if fallbackClient != nil {
-		resolver = pin.NewVersionResolver(primaryClient.Repositories, fallbackClient.Repositories)
+		fallbackRepos = fallbackClient.Repositories
 	}
+	resolver := pin.NewVersionResolver(primaryClient.Repositories, fallbackRepos)
 	return Pin{
 		resolver:            &resolver,
 		ignoreOwners:        ignoreOwners,

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -23,8 +23,12 @@ type Pin struct {
 	strictPinning202508 bool
 }
 
-func NewPin(client *gogithub.Client, ignoreOwners, ignoreRepos []string, strictPinning202508 bool) Pin {
-	resolver := pin.NewVersionResolver(client.Repositories)
+// NewPin creates a pin command with primary GitHub client and optional fallback GitHub.com client.
+func NewPin(primaryClient *gogithub.Client, fallbackClient *gogithub.Client, ignoreOwners, ignoreRepos []string, strictPinning202508 bool) Pin {
+	resolver := pin.NewVersionResolver(primaryClient.Repositories, nil)
+	if fallbackClient != nil {
+		resolver = pin.NewVersionResolver(primaryClient.Repositories, fallbackClient.Repositories)
+	}
 	return Pin{
 		resolver:            &resolver,
 		ignoreOwners:        ignoreOwners,

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -45,10 +45,15 @@ func (p *Pin) Apply(ctx context.Context, input string) (string, bool, error) {
 
 	changed := false
 	resultLines := make([]string, 0, len(lines))
+
+	var errs []error
 	for _, line := range lines {
 		modifiedLine, lineChanged, err := p.replaceLine(ctx, line)
 		if err != nil {
-			return "", false, err
+			// Collect errors but continue processing remaining actions/lines.
+			errs = append(errs, err)
+			resultLines = append(resultLines, line)
+			continue
 		}
 
 		if lineChanged {

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -66,13 +66,10 @@ func (p *Pin) Apply(ctx context.Context, input string) (string, bool, error) {
 	// Join lines back into a single string using strings.Join (more efficient than concatenation)
 	output := strings.Join(resultLines, "\n")
 
-	return output, changed, nil
 	if len(errs) > 0 {
 		return output, changed, errors.Join(errs...)
 	}
-
 	return output, changed, nil
- }
 }
 
 func (p *Pin) replaceLine(ctx context.Context, line string) (string, bool, error) {

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -2,6 +2,7 @@ package pin
 
 import (
 	"context"
+	"log/slog"
 	"regexp"
 	"slices"
 	"strings"

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -67,6 +67,12 @@ func (p *Pin) Apply(ctx context.Context, input string) (string, bool, error) {
 	output := strings.Join(resultLines, "\n")
 
 	return output, changed, nil
+	if len(errs) > 0 {
+		return output, changed, errors.Join(errs...)
+	}
+
+	return output, changed, nil
+ }
 }
 
 func (p *Pin) replaceLine(ctx context.Context, line string) (string, bool, error) {


### PR DESCRIPTION
# 🎉 Support Github Enterprise Server/Cloud 

* Just using the `env.GITHUB_API_SERVER` in case it's provided for ALL API calls without any fallback
* Use the config property as first precedence when configured through a config file
* Added capabilities to support a more granular approach in Github Pull Requests:
  * strict files list from the PR 

# 🐛 Bugfixes

* The CLI was incorrectly handling the restrictions of owners... 

# 📸 Screenshots

* The full Github Suggested Changes, supported from Github Enterprise 3.18.x forward, is fully supported

> [!NOTE]
> * There's a list of 50 files to be reported in the PR with `reviewdog`.
> * If the list is larger than that, the Github Suggested Changes will NOT Show up

Here's an example on Github Enterprise Server, bypassing the ReviewDog's API Token and using the Github Actions approach:

<img width="1023" height="970" alt="Screenshot 2026-01-30 at 11 37 38 AM copy" src="https://github.com/user-attachments/assets/320e9550-4347-4577-bd7d-ba51be632c82" />

# :octocat: Ticket

* Fixes requirement at https://github.com/Finatext/gha-fix/issues/19

# ✅ Test Cases

* Updated with the verification of the new configs

# 📚 Docs

* Adding remarks  
* Show config examples for the new config section

# ⌨️ Tests

* Setup

```console
go install ./...

$ go env GOBIN GOPATH

/Users/mdesales/go

```console
$  /Users/mdesales/go/bin/gha-fix pin --help
Pin GitHub Actions used in workflow files (.yml or .yaml) to specific commit SHAs.

This command scans GitHub Actions in workflow files and replaces references like 'owner/repo@v1'
with specific commit SHAs like 'owner/repo@8843d7f53bd34e3b78f2acee556ba5d53feae7c4'.

Usage:
  pin [file1 file2 ...]

If no files are specified, all workflow files (.yml or .yaml) in the current directory
and subdirectories will be processed.

You can customize the behavior with the following options:
  --ignore-owners: Skip actions from specific owners (e.g., "actions,github")
  --ignore-repos: Skip specific repositories (e.g., "actions/checkout,docker/login-action")
  --strict-pinning-202508: Enable strict SHA pinning for composite actions (GitHub's SHA pinning enforcement policy)
  --api-server: Full GitHub API base URL (e.g., https://github.enterprise.company.com/api/v3/)

The --strict-pinning-202508 option implements support for GitHub's SHA pinning enforcement policy
announced in August 2025. When enabled:
  - Composite actions (e.g., actions/checkout@v4) will be pinned to SHAs even if owner is in ignore-owners
  - Reusable workflows (e.g., org/repo/.github/workflows/build.yml@main) still respect ignore-owners

This helps organizations comply with GitHub's security policies while maintaining flexibility
for reusable workflows. See: https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/

Global options:
  --ignore-dirs: Skip specific directories when searching for workflow files (e.g., "node_modules,dist")

Note: GITHUB_TOKEN environment variable is required to fetch tags and commit SHAs from GitHub.

Usage:
  gha-fix pin [flags]

Flags:
      --api-server string                Full GitHub API base URL (e.g., https://github.enterprise.company.com/api/v3). When specified, you must provide 'github-enterprise-token'
      --github-enterprise-token string   GitHub Enterprise token for accessing the configured --api-server (can also be set via GITHUB_ENTERPRISE_TOKEN env var or pin.github-enterprise-token in config)
      --github-token string              GitHub token for accessing GitHub.com API (can also be set via GITHUB_TOKEN env var or pin.github-token in config)
  -h, --help                             help for pin
      --ignore-owners strings            Comma-separated list of owners to ignore
      --ignore-repos strings             Comma-separated list of repos to ignore in format owner/repo
      --strict-pinning-202508            Enable strict SHA pinning for composite actions (GitHub's SHA pinning enforcement policy)

Global Flags:
  -c, --config string         config file (default is ./gha-fix.yaml)
      --ignore-dirs strings   Comma-separated list of directory names to ignore when searching for workflow files (default [.git,node_modules,dist,out,vendor,.idea,.vscode,bin,build,tmp,coverage,.cache,__pycache__])
  -l, --log-level string      set log level (debug, info, warn, error) (default "info")

$ /Users/mdesales/go/bin/gha-fix pin --api-server https://github.company.com/api/v3 --github-enterprise-token ghp_gU********es
2025-12-30 17:31:15.067 INF no changes needed. all GitHub Actions are already pinned or no actions found.
```

## ⌨️ Test with wrong token

```console
$ /Users/mdesales/go/bin/gha-fix pin --api-server https://github.company.com/api/v3 --github-token ghp_gUes
2025-12-30 17:29:21.030 ERR GitHub Enterprise token is required when using --api-server. Set --github-enterprise-token, pin.github-enterprise-token, or GITHUB_ENTERPRISE_TOKEN.

$ /Users/mdesales/go/bin/gha-fix pin --api-server https://github.company.com/api/v3 --github-enterprise-token ghp_g*****Ues
2025-12-30 13:29:46.107 ERR failed to pin actions error=failed to process file: action.yaml: failed to replace actions in file: action.yaml: failed to resolve version for seceng-devsecops-platform/wearerequired-slack-messaging-action@v3.0.0: failed to list tags for seceng-devsecops-platform/wearerequired-slack-messaging-action: GET https://github.company.com/api/v3/repos/seceng-devsecops-platform/wearerequired-slack-messaging-action/tags?per_page=100: 403  []
```

# ⌨️ Tests without Github.com token

* It may fail depending on your IP address 
* It might just fail with a bad credential 

```console
$ /Users/mdesales/go/bin/gha-fix pin --api-server https://git.viasat.com/api/v3 --github-enterprise-token ghp_g******TUes --log-level debug
2025-12-30 15:58:05.929 DBG searching for workflow files to process
2025-12-30 15:58:05.931 DBG skipping directory path=build name=build
2025-12-30 15:58:05.937 DBG found workflow files count=15
2025-12-30 15:58:05.937 DBG processing file path=custom/load-mapped-repos-to-matrix/action.yaml
2025-12-30 15:58:05.940 DBG processing file path=docker/prisma-cloud-scan-reporter/action.yaml
2025-12-30 15:58:05.945 DBG processing file path=docker/sbom-reporter/action.yaml
2025-12-30 15:58:05.951 DBG processing file path=github/check-runs-create/action.yaml
2025-12-30 15:58:05.954 DBG processing file path=github/check-runs-synchronized/action.yaml
2025-12-30 15:58:05.958 DBG processing file path=github/check-runs-terminate/action.yaml
2025-12-30 15:58:05.961 DBG processing file path=github/ghas-dependabot-metadata/action.yaml
2025-12-30 15:58:05.967 DBG fetching tags for version resolution owner=actions repo=checkout page=0
2025-12-30 15:58:07.101 DBG fetching tags for version resolution owner=dependabot repo=fetch-metadata page=0
2025-12-30 15:58:07.430 DBG fallback to github.com owner=dependabot repo=fetch-metadata page=0
2025-12-30 15:58:08.449 ERR failed to pin actions error=failed to process file: github/ghas-dependabot-metadata/action.yaml: failed to replace actions in file: github/ghas-dependabot-metadata/action.yaml: failed to resolve version for dependabot/fetch-metadata@v2.3.0: failed to list tags for dependabot/fetch-metadata: GET https://api.github.com/repos/dependabot/fetch-metadata/tags?per_page=100: 401 Bad credentials []
```

# ⌨️ Tests with fallback

* When a github.com token is not provided, then the pin may also fail due to the fact of a rate limit... 
* The example is with the dependabot action, which is NOT mirrored in Github Enterprise servers... Then, API calls to `https://api.github.com/repos/dependabot/fetch-metadata/tags` may also be throttled for a developer without an GITHUB_TOKEN.
* Actions from mirror repos, custom reusable actions included
* Actions that are NOT mirrored, and are checked with the github.com fallback

```console
$ /Users/mdesales/go/bin/gha-fix pin --api-server https://github.company.com/api/v3 --github-enterprise-token ghp_gY***TUes --log-level debug
2025-12-30 15:58:05.929 DBG searching for workflow files to process
2025-12-30 15:58:05.931 DBG skipping directory path=build name=build
2025-12-30 15:58:05.937 DBG found workflow files count=15
2025-12-30 15:58:05.937 DBG processing file path=custom/load-mapped-repos-to-matrix/action.yaml
2025-12-30 15:58:05.940 DBG processing file path=docker/prisma-cloud-scan-reporter/action.yaml
2025-12-30 15:58:05.945 DBG processing file path=docker/sbom-reporter/action.yaml
2025-12-30 15:58:05.951 DBG processing file path=github/check-runs-create/action.yaml
2025-12-30 15:58:05.954 DBG processing file path=github/check-runs-synchronized/action.yaml
2025-12-30 15:58:05.958 DBG processing file path=github/check-runs-terminate/action.yaml
2025-12-30 15:58:05.961 DBG processing file path=github/ghas-dependabot-metadata/action.yaml
2025-12-30 15:58:05.967 DBG fetching tags for version resolution owner=actions repo=checkout page=0
2025-12-30 15:58:07.101 DBG fetching tags for version resolution owner=dependabot repo=fetch-metadata page=0
2025-12-30 15:58:07.430 DBG fallback to github.com owner=dependabot repo=fetch-metadata page=0
2025-12-30 15:58:08.449 ERR failed to pin actions error=failed to process file: github/ghas-dependabot-metadata/action.yaml: failed to replace actions in file: github/ghas-dependabot-metadata/action.yaml: failed to resolve version for dependabot/fetch-metadata@v2.3.0: failed to list tags for dependabot/fetch-metadata: GET https://api.github.com/repos/dependabot/fetch-metadata/tags?per_page=100: 401 Bad credentials []
```

* When the token is then provided for both the Enterprise and Github.com, then patching is always guaranteed as the Github.com Token rate limit is also risen.

```console
$ /Users/mdesales/go/bin/gha-fix pin --api-server https://github.company.com/api/v3 --github-enterprise-token ghp_g****TUes --log-level debug --github-token ghp_5****3My1
2025-12-30 15:59:09.794 DBG searching for workflow files to process
2025-12-30 15:59:09.797 DBG skipping directory path=build name=build
2025-12-30 15:59:09.803 DBG found workflow files count=15
2025-12-30 15:59:09.803 DBG processing file path=custom/load-mapped-repos-to-matrix/action.yaml
2025-12-30 15:59:09.803 DBG processing file path=docker/prisma-cloud-scan-reporter/action.yaml
2025-12-30 15:59:09.804 DBG processing file path=docker/sbom-reporter/action.yaml
2025-12-30 15:59:09.804 DBG processing file path=github/check-runs-create/action.yaml
2025-12-30 15:59:09.805 DBG processing file path=github/check-runs-synchronized/action.yaml
2025-12-30 15:59:09.806 DBG processing file path=github/check-runs-terminate/action.yaml
2025-12-30 15:59:09.806 DBG processing file path=github/ghas-dependabot-metadata/action.yaml
2025-12-30 15:59:09.807 DBG fetching tags for version resolution owner=actions repo=checkout page=0
2025-12-30 15:59:10.742 DBG fetching tags for version resolution owner=dependabot repo=fetch-metadata page=0
2025-12-30 15:59:11.037 DBG fallback to github.com owner=dependabot repo=fetch-metadata page=0
2025-12-30 15:59:12.140 DBG fetching tags for version resolution owner=actions repo=github-script page=0
2025-12-30 15:59:12.489 INF file updated path=github/ghas-dependabot-metadata/action.yaml
2025-12-30 15:59:12.489 DBG processing file path=github/ghas-enablement-status/action.yaml
2025-12-30 15:59:12.511 INF file updated path=github/ghas-enablement-status/action.yaml
2025-12-30 15:59:12.511 DBG processing file path=github/mermaid-diagrams/gh-action/action.yaml
2025-12-30 15:59:12.529 INF file updated path=github/mermaid-diagrams/gh-action/action.yaml
2025-12-30 15:59:12.529 DBG processing file path=github/workflow-run-logs/action.yaml
2025-12-30 15:59:12.535 DBG processing file path=github/workflow-run-logs-grep/action.yaml
2025-12-30 15:59:12.540 DBG fetching tags for version resolution owner=seceng-devsecops-platform repo=qoomon-actions--context page=0
2025-12-30 15:59:12.881 DBG fetching commit SHA for branch owner=seceng-devsecops-platform repo=devsecops-platform-github-workflows ref=main
2025-12-30 15:59:13.221 INF file updated path=github/workflow-run-logs-grep/action.yaml
2025-12-30 15:59:13.221 DBG processing file path=messaging/slack-notification/action.yaml
2025-12-30 15:59:13.226 DBG fetching tags for version resolution owner=seceng-devsecops-platform repo=wearerequired-slack-messaging-action page=0
2025-12-30 15:59:13.549 INF file updated path=messaging/slack-notification/action.yaml
2025-12-30 15:59:13.549 DBG processing file path=messaging/slack-notification/arc_harden_runner_values.yaml
2025-12-30 15:59:13.550 DBG processing file path=platform/core/set-base-values/action.yaml
2025-12-30 15:59:13.553 DBG processing file path=platform/core/set-docker-image-settings/action.yaml
2025-12-30 15:59:13.557 INF successfully pinned GitHub Actions to specific commit SHAs changed=5
```

* Here's a full diff example where mirror actions are fetched locally
  * actions/checkout

```diff
diff --git a/actions/custom/load-mapped-repos-to-matrix/action.yaml b/actions/custom/load-mapped-repos-to-matrix/action.yaml
index 180d4ac..91018fe 100644
--- a/actions/custom/load-mapped-repos-to-matrix/action.yaml
+++ b/actions/custom/load-mapped-repos-to-matrix/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Checkout the customer .github repo
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Read the entries in ${{ inputs.mirrored-repos-map-file }}
       shell: bash
diff --git a/actions/docker/prisma-cloud-scan-reporter/action.yaml b/actions/docker/prisma-cloud-scan-reporter/action.yaml
index 7171310..9d8060b 100644
--- a/actions/docker/prisma-cloud-scan-reporter/action.yaml
+++ b/actions/docker/prisma-cloud-scan-reporter/action.yaml
@@ -190,7 +190,7 @@ runs:
         fi
 
     - name: Add Prisma Cloud PR Comment
-      uses: seceng-devsecops-platform/marocchino-sticky-pull-request-comment-action@v2
+      uses: seceng-devsecops-platform/marocchino-sticky-pull-request-comment-action@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
       if: ${{ steps.scan-check.outputs.scan-report-generated == 'true' }}
       with:
         header: prisma-scan-result-${{ inputs.docker-image-repo-tag }}
diff --git a/actions/docker/sbom-reporter/action.yaml b/actions/docker/sbom-reporter/action.yaml
index 3268142..522a708 100644
--- a/actions/docker/sbom-reporter/action.yaml
+++ b/actions/docker/sbom-reporter/action.yaml
@@ -135,7 +135,7 @@ runs:
         fi
 
     - name: Add Docker SBOM PR Comment
-      uses: seceng-devsecops-platform/marocchino-sticky-pull-request-comment-action@v2
+      uses: seceng-devsecops-platform/marocchino-sticky-pull-request-comment-action@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
       if: ${{ steps.sbom-check.outputs.sbom-generated == 'true' && inputs.add-comment-to-current-pr == 'true' }}
       with:
         header: sbom-report-${{ inputs.docker-image-repo-tag }}
diff --git a/actions/github/check-runs-synchronized/action.yaml b/actions/github/check-runs-synchronized/action.yaml
index 939cb7a..efd8c1c 100644
--- a/actions/github/check-runs-synchronized/action.yaml
+++ b/actions/github/check-runs-synchronized/action.yaml
@@ -44,7 +44,7 @@ runs:
       shell: bash
 
     - name: Synchronize on all workflows in the current PR with currently defined PR checks
-      uses: seceng-devsecops-platform/wechuli-allcheckspassed@v2.1.0
+      uses: seceng-devsecops-platform/wechuli-allcheckspassed@f423b273f5fdf73582e41f8f6f0f204d69c27379 # v2.1.0
       with:
           token: ${{ inputs.github-token }}
           # https://github.com/marketplace/actions/allcheckspassed#fail-fast
diff --git a/actions/github/ghas-dependabot-metadata/action.yaml b/actions/github/ghas-dependabot-metadata/action.yaml
index ccf6b1d..5cec368 100644
--- a/actions/github/ghas-dependabot-metadata/action.yaml
+++ b/actions/github/ghas-dependabot-metadata/action.yaml
@@ -25,11 +25,11 @@ runs:
   using: composite
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     
     - name: Dependabot metadata
       id: metadata
-      uses: dependabot/fetch-metadata@v2.3.0
+      uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
       with:
         github-token: "${{ inputs.github-token }}"
         # Warning: Dependabot's commit signature is not verified, refusing to proceed.
@@ -76,7 +76,7 @@ runs:
     
     - name: Add PR comment with metadata
       id: pr-metadata
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |
diff --git a/actions/github/ghas-enablement-status/action.yaml b/actions/github/ghas-enablement-status/action.yaml
index c6b718f..fdf3160 100644
--- a/actions/github/ghas-enablement-status/action.yaml
+++ b/actions/github/ghas-enablement-status/action.yaml
@@ -25,7 +25,7 @@ runs:
   using: composite
   steps:
     - name: Check if GHAS is enabled
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       id: status
       with:
         github-token: ${{ inputs.github-token }}
diff --git a/actions/github/mermaid-diagrams/gh-action/action.yaml b/actions/github/mermaid-diagrams/gh-action/action.yaml
index 457d3fc..a89919b 100644
--- a/actions/github/mermaid-diagrams/gh-action/action.yaml
+++ b/actions/github/mermaid-diagrams/gh-action/action.yaml
@@ -37,7 +37,7 @@ runs:
   steps:
     - name: Convert action to Mermaid + Usage
       id: action-diagram
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       env:
         ORG_REPO_URL: ${{ inputs.org-repo-url }}
         TARGET_REF: ${{ inputs.ref }}
diff --git a/actions/github/workflow-run-logs-grep/action.yaml b/actions/github/workflow-run-logs-grep/action.yaml
index 472b2fc..c74a5cc 100644
--- a/actions/github/workflow-run-logs-grep/action.yaml
+++ b/actions/github/workflow-run-logs-grep/action.yaml
@@ -57,7 +57,7 @@ runs:
   steps:
     - name: Fetch additional workflow properties
       id: workflow-metadata
-      uses: seceng-devsecops-platform/qoomon-actions--context@v4
+      uses: seceng-devsecops-platform/qoomon-actions--context@33b43056fae95271265b29b702dcf5ea3f7708b2 # v4.0.3
 
     - name: View Envs and Outputs
       shell: bash
@@ -74,7 +74,7 @@ runs:
 
     - name: Retrieve the logs from the workflow
       id: workflow-logs
-      uses: seceng-devsecops-platform/devsecops-platform-github-workflows/actions/github/workflow-run-logs@main
+      uses: seceng-devsecops-platform/devsecops-platform-github-workflows/actions/github/workflow-run-logs@719d0b2e862fe65704d1ed53048bc8fe93e1dd61 # main
       with:
         github-org-repo: ${{ inputs.github-org-repo }}
         github-token: ${{ inputs.github-token }}
diff --git a/actions/messaging/slack-notification/action.yaml b/actions/messaging/slack-notification/action.yaml
index 05d9f95..855c260 100644
--- a/actions/messaging/slack-notification/action.yaml
+++ b/actions/messaging/slack-notification/action.yaml
@@ -131,7 +131,7 @@ runs:
     - id: message
       if: ${{ inputs.messageId == '' }}
       name: New message without updating
-      uses: seceng-devsecops-platform/wearerequired-slack-messaging-action@v3.0.0
+      uses: seceng-devsecops-platform/wearerequired-slack-messaging-action@b8d341605efb42cb7ca093a88faaffee59176928 # v3.0.0
       with:
         bot_token: ${{ inputs.slackBotToken }}
         channel_id: ${{ inputs.channelId }}
@@ -140,7 +140,7 @@ runs:
     - id: message_update
       if: ${{ inputs.messageId != '' }}
       name: Update existing message ${{ inputs.messageId }}
-      uses: seceng-devsecops-platform/wearerequired-slack-messaging-action@v3.0.0
+      uses: seceng-devsecops-platform/wearerequired-slack-messaging-action@b8d341605efb42cb7ca093a88faaffee59176928 # v3.0.0
       with:
         bot_token: ${{ inputs.slackBotToken }}
         channel_id: ${{ inputs.channelId }}
```